### PR TITLE
missed a line in path fix

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -135,7 +135,7 @@ def check_config():
             )
     
     if not os.path.isfile(config.VLC.get('path', "")):
-        raise RuntimeError('Invalid path to VLC: %s.' % config.VLC['path'])
+        raise RuntimeError('Invalid path to VLC: %s.' % config.VLC.get('path'], None))
 
 
 try:


### PR DESCRIPTION
the error message was missing the `get`, which would have still caused an unhandled exception